### PR TITLE
Issue-2-snapshots

### DIFF
--- a/libs/eventually-express/src/ExpressApp.ts
+++ b/libs/eventually-express/src/ExpressApp.ts
@@ -1,12 +1,8 @@
 import {
   Aggregate,
-  AggregateFactory,
-  aggregatePath,
-  AppBase,
-  Broker,
-  committedSchema,
-  config,
-  Errors,
+  AggregateFactory, aggregatePath, AppBase,
+  Broker, committedSchema,
+  config, Errors,
   Evt,
   ExternalSystemFactory,
   InMemoryBroker,
@@ -27,8 +23,10 @@ import express, {
 } from "express";
 import { Server } from "http";
 
+
 type GetCallback = <M extends Payload, C, E>(
-  aggregate: Aggregate<M, C, E>
+  aggregate: Aggregate<M, C, E>,
+  noSnapshots?: boolean
 ) => Promise<Snapshot<M> | Snapshot<M>[]>;
 
 export class ExpressApp extends AppBase {
@@ -81,7 +79,8 @@ export class ExpressApp extends AppBase {
       ) => {
         try {
           const { id } = req.params;
-          const result = await callback(factory(id));
+          const noSnapshots = (req.query || {}).noSnapshots;
+          const result = await callback(factory(id), ['true','1'].includes(noSnapshots as string));
           let etag = "-1";
           if (Array.isArray(result)) {
             if (result.length) etag = result[result.length - 1].event.version;

--- a/libs/eventually-pg/src/PostgresStore.ts
+++ b/libs/eventually-pg/src/PostgresStore.ts
@@ -51,6 +51,14 @@ export const PostgresStore = (table: string): Store => ({
     await pool.end();
   },
 
+  getLastEvent: async (stream:string)=> {
+    return pool.query<Event>(
+      `SELECT * FROM ${table} WHERE stream=$1 ORDER BY version DESC LIMIT 1`,
+      [stream]
+    )
+      .then(x=> x.rows.length && formatEvent(x.rows[0]))
+  },
+
   load: async <E>(
     stream: string,
     reducer: (event: EvtOf<E>) => void

--- a/libs/eventually/src/AppBase.ts
+++ b/libs/eventually/src/AppBase.ts
@@ -317,6 +317,20 @@ export abstract class AppBase {
   }
 
   /**
+   * Loads the last snapshot for the given stream.
+   * @param stream The stream to load the snapshot for
+   * @returns Instance of Snappshot (event, state)
+   */
+  async loadSnapshot<M extends Payload>(stream:string): Promise<Snapshot<M>>{
+    const event = await this._store.getLastEvent(`${stream}-snapshot`);
+    event && this.log.trace(
+      "white",
+      `<<< SNAPSHOT Loaded`,
+      `Stream: ${stream}`
+    );
+    return event?.data as {state: M, event:Evt};
+  }
+  /**
    * Loads current model state
    * @param reducer model reducer
    * @param callback optional reduction predicate

--- a/libs/eventually/src/AppBase.ts
+++ b/libs/eventually/src/AppBase.ts
@@ -330,6 +330,26 @@ export abstract class AppBase {
     );
     return event?.data as {state: M, event:Evt};
   }
+
+  /**
+   * Saves the given payload as snapshot for the stream
+   * @param stream The stream to save the snapshot for
+   * @param snapshot Instance of Snappshot (event, state)
+   */
+  async saveSnapshot<M extends Payload>(stream:string, snapshot: Snapshot<M>):Promise<void>{
+    this.log.trace(
+      "white",
+      `<<< SNAPSHOT generated`,
+      `Stream: ${stream} Event: ${snapshot.event.id}`
+    );
+    await this._store.commit(
+      `${stream}-snapshot`, [{
+        name: 'Snapshot', 
+        data: snapshot,
+        schema: ()=> Joi.object<Message<"Snapshot", Snapshot<M>>>()
+      }]);
+  }
+
   /**
    * Loads current model state
    * @param reducer model reducer

--- a/libs/eventually/src/Store.ts
+++ b/libs/eventually/src/Store.ts
@@ -16,6 +16,12 @@ export interface Store {
   close: () => Promise<void>;
 
   /**
+   * Loads the last event for the stream. Used for loading snapshots
+   * @param stream stream name
+   */
+  getLastEvent: (stream:string)=> Promise<Evt>
+
+  /**
    * Loads aggregate in memory by reading stream and reducing model
    * @param stream stream name
    * @param reducer model reducer

--- a/libs/eventually/src/Store.ts
+++ b/libs/eventually/src/Store.ts
@@ -1,4 +1,4 @@
-import { EvtOf, Evt, MsgOf } from "./types";
+import { Evt, EvtOf, MsgOf } from "./types";
 
 /**
  * Stores persist event messages into streams correlated by aggregate id
@@ -26,10 +26,8 @@ export interface Store {
    * @param stream stream name
    * @param reducer model reducer
    */
-  load: <E>(
-    stream: string,
-    reducer: (event: EvtOf<E>) => void
-  ) => Promise<void>;
+  load <E>( stream: string, reducer: (event: EvtOf<E>) => void ): Promise<void>;
+  load <E>( stream: string, afterEvent: number, reducer: (event: EvtOf<E>) => void ): Promise<void>;
 
   /**
    * Commits message into stream of aggregate id

--- a/libs/eventually/src/__dev__/InMemoryStore.ts
+++ b/libs/eventually/src/__dev__/InMemoryStore.ts
@@ -10,8 +10,10 @@ export const InMemoryStore = (): Store => {
       reducer: (event: EvtOf<E>) => void
       // eslint-disable-next-line
     ): Promise<void> => {
+
+    getLastEvent: (stream:string) => {
       const events = _events.filter((e) => e.stream === stream);
-      events.map(reducer);
+      return Promise.resolve(events[events.length -1]);
     },
 
     commit: async <E>(

--- a/libs/eventually/src/__dev__/InMemoryStore.ts
+++ b/libs/eventually/src/__dev__/InMemoryStore.ts
@@ -1,4 +1,5 @@
-import { EvtOf, Evt, MsgOf } from "../types";
+import { Evt, EvtOf, MsgOf } from "../types";
+
 import { Store } from "../Store";
 
 export const InMemoryStore = (): Store => {
@@ -7,9 +8,17 @@ export const InMemoryStore = (): Store => {
   return {
     load: async <E>(
       stream: string,
-      reducer: (event: EvtOf<E>) => void
-      // eslint-disable-next-line
+      afterEvent: number | ((event: EvtOf<E>) => void),
+      reducer?: (event: EvtOf<E>) => void
     ): Promise<void> => {
+      if (typeof afterEvent === 'function'){
+        reducer = afterEvent;
+        afterEvent = -1;
+      }
+      const events = _events.slice(afterEvent+1).filter((e) => e.stream === stream);
+      events.map(reducer);
+      return Promise.resolve();
+    },
 
     getLastEvent: (stream:string) => {
       const events = _events.filter((e) => e.stream === stream);

--- a/libs/eventually/src/types.ts
+++ b/libs/eventually/src/types.ts
@@ -63,6 +63,7 @@ export type Snapshot<M extends Payload> = {
 export type ModelReducer<M extends Payload, E> = {
   stream: () => string;
   init: () => Readonly<M>;
+  snapshotEventsThreshold?: number
 } & {
   [Name in keyof E as `apply${Capitalize<Name & string>}`]: (
     state: Readonly<M>,

--- a/libs/eventually/src/utils.ts
+++ b/libs/eventually/src/utils.ts
@@ -1,4 +1,5 @@
 import * as joi from "joi";
+
 import {
   AggregateFactory,
   Evt,
@@ -143,3 +144,9 @@ export const Singleton =
     if (!instances[target.name]) instances[target.name] = target(...args);
     return instances[target.name] as T;
   };
+
+
+export const shouldStoreSnapshot = (lastCommittedEvent: {version:string}, snapshotEventsThreshold?:number):boolean => 
+  snapshotEventsThreshold && 
+  lastCommittedEvent.version !== '0' && 
+  Number(lastCommittedEvent.version) % snapshotEventsThreshold === 0

--- a/services/calculator/src/__tests__/express.spec.ts
+++ b/services/calculator/src/__tests__/express.spec.ts
@@ -1,10 +1,11 @@
 import { App, EvtOf } from "@rotorsoft/eventually";
 import { ExpressApp } from "@rotorsoft/eventually-express";
 import { Calculator } from "../calculator.aggregate";
-import { Counter, StatelessCounter } from "../counter.policy";
 import { commands } from "../calculator.commands";
 import { Events, events } from "../calculator.events";
-import { command, event, load, read, stream, get } from "./http";
+import { Counter, StatelessCounter } from "../counter.policy";
+import { command, event, get, load, read, stream } from "./http";
+
 
 const app = App(new ExpressApp())
   .withEvents(events)
@@ -39,7 +40,7 @@ describe("express app", () => {
         result: 3.3
       });
 
-      const snapshots = await stream(Calculator, "test");
+      const snapshots = await stream(Calculator, "test", true);
       expect(snapshots.length).toEqual(6);
     });
 
@@ -63,8 +64,13 @@ describe("express app", () => {
     });
 
     it("should read aggregate stream", async () => {
-      const snapshots = await stream(Calculator, "test2");
+      const snapshots = await stream(Calculator, "test2", true);
       expect(snapshots.length).toBe(9);
+    });
+    
+    it("should read aggregate stream using snapshots", async () => {
+      const snapshots = await stream(Calculator, "test2");
+      expect(snapshots.length).toBe(1);
     });
 
     it("should not load events", async () => {

--- a/services/calculator/src/__tests__/http.ts
+++ b/services/calculator/src/__tests__/http.ts
@@ -1,15 +1,8 @@
 import {
-  aggregateCommandPath,
-  AggregateFactory,
-  aggregatePath,
-  Evt,
-  EvtOf,
-  externalSystemCommandPath,
-  ExternalSystemFactory,
+  aggregateCommandPath, AggregateFactory, aggregatePath, Evt,
+  EvtOf, externalSystemCommandPath, ExternalSystemFactory,
   MsgOf,
-  Payload,
-  policyEventPath,
-  PolicyFactory,
+  Payload, policyEventPath, PolicyFactory,
   PolicyResponse,
   Snapshot
 } from "@rotorsoft/eventually";
@@ -71,10 +64,11 @@ export const load = async <M extends Payload, C, E>(
 
 export const stream = async <M extends Payload, C, E>(
   factory: AggregateFactory<M, C, E>,
-  id: string
+  id: string,
+  noSnapshots = false
 ): Promise<Snapshot<M>[]> => {
   const { data } = await axios.get<any, AxiosResponse<Snapshot<M>[]>>(
-    url(aggregatePath(factory).path.replace(":id", id).concat("/stream"))
+    url(aggregatePath(factory).path.replace(":id", id).concat("/stream").concat(`${noSnapshots ? '?noSnapshots=1' : ''}`))
   );
   return data;
 };

--- a/services/calculator/src/__tests__/inmemory.spec.ts
+++ b/services/calculator/src/__tests__/inmemory.spec.ts
@@ -42,8 +42,14 @@ describe("in memory app", () => {
         operator: "+",
         result: 3.3
       });
-      const snapshots = await app.stream(test);
-      expect(snapshots.length).toEqual(6);
+      
+      // With no Snapshot loading
+      const snapshots1 = await app.stream(test, true);
+      expect(snapshots1.length).toEqual(6);
+      
+      // With Snapshot loading
+      const snapshots2 = await app.stream(test);
+      expect(snapshots2.length).toEqual(1);
     });
 
     it("should compute correctly 2", async () => {
@@ -94,8 +100,13 @@ describe("in memory app", () => {
     });
 
     it("should read aggregate stream", async () => {
-      const snapshots = await app.stream(Calculator("test2"));
+      const snapshots = await app.stream(Calculator("test2"), true);
       expect(snapshots.length).toBe(9);
+    });
+
+    it("should read aggregate stream using Snapshots", async () => {
+      const snapshots = await app.stream(Calculator("test2"));
+      expect(snapshots.length).toBe(1);
     });
 
     it("should throw concurrency error", async () => {
@@ -144,7 +155,8 @@ describe("in memory app", () => {
       expect(state).toEqual({ result: 0 });
 
       const stream = await app.stream(
-        Counter(event as EvtOf<CounterEvents>).reducer
+        Counter(event as EvtOf<CounterEvents>).reducer,
+        true
       );
       expect(stream.length).toBe(5);
     });

--- a/services/calculator/src/calculator.aggregate.ts
+++ b/services/calculator/src/calculator.aggregate.ts
@@ -1,14 +1,15 @@
 import { Aggregate, CommittedEvent } from "@rotorsoft/eventually";
 import {
-  DIGITS,
-  SYMBOLS,
-  Digits,
   CalculatorModel,
+  DIGITS,
+  Digits,
+  Keys,
   Operators,
-  Keys
+  SYMBOLS
 } from "./calculator.models";
-import { Commands } from "./calculator.commands";
 import { Events, events } from "./calculator.events";
+
+import { Commands } from "./calculator.commands";
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 const Operations = {
@@ -33,7 +34,7 @@ export const Calculator = (
   id: string
 ): Aggregate<CalculatorModel, Omit<Commands, "Whatever">, Events> => ({
   stream: () => `Calculator:${id}`,
-
+  snapshotEventsThreshold: 2,
   // Model Reducer with event side effects
   init: (): CalculatorModel => ({
     result: 0

--- a/services/calculator/src/counter.policy.ts
+++ b/services/calculator/src/counter.policy.ts
@@ -7,6 +7,7 @@ import {
 } from "@rotorsoft/eventually";
 import { Commands, commands } from "./calculator.commands";
 import { CounterState, Digits } from "./calculator.models";
+
 import { Calculator } from "./calculator.aggregate";
 import { Events } from "./calculator.events";
 
@@ -42,6 +43,7 @@ export const Counter = (
 
   reducer: {
     stream: () => `Counter:${event.stream}`,
+    snapshotEventsThreshold: 3,
     init: (): CounterState => ({ count: 0 }),
     applyDigitPressed: (model: CounterState) => {
       return { count: model.count + 1 };


### PR DESCRIPTION
Adds configurable snapshot functionality to events using the int snapshotEventsThreshold to determine the amount of events that will generate a snapshot. No snapshot will be taken for the stream if value is falsy.

example on aggregates
```
export const Calculator = (
  id: string
): Aggregate<CalculatorModel, Omit<Commands, "Whatever">, Events> => ({
  stream: () => `Calculator:${id}`,
  snapshotEventsThreshold: 2,
...
```

example on policies:
```
export const Counter = (
  event: EvtOf<CounterEvents>
): Policy<Commands, CounterEvents, CounterState> => ({
...
 reducer: {
    stream: () => `Counter:${event.stream}`,
    snapshotEventsThreshold: 3,
    init: (): CounterState => ({ count: 0 }),
    applyDigitPressed: (model: CounterState) => {
      return { count: model.count + 1 };
    },
    applyDotPressed: (model: CounterState) => {
      return { count: model.count + 1 };
    }
  }
});
```
