### PR TITLE
feat: add caching to eventually config getPackage()

### DIFF
--- a/libs/eventually/src/config.ts
+++ b/libs/eventually/src/config.ts
@@ -18,9 +18,14 @@ type Package = {
   dependencies: Record<string, string>;
 };
 
+let parsedPkg: Package;
+
 const getPackage = (): Package => {
-  const pkg = fs.readFileSync("package.json");
-  return JSON.parse(pkg.toString()) as unknown as Package;
+  if(!parsedPkg){
+    const pkg = fs.readFileSync("package.json");
+    parsedPkg = JSON.parse(pkg.toString()) as unknown as Package;
+  }
+  return parsedPkg
 };
 
 const Schema = z.object({


### PR DESCRIPTION
This could also be considered a fix.  The getPackage() function is called multiple times during almost every operation within eventually lib and it was calling readFileSync() every time as well.  I know the OS does some caching but this seems to be wildly inefficient so this PR adds caching to that function.