### PR TITLE
fix: eventually-openapi config again to work with firebase emulator

### DIFF
--- a/libs/eventually-openapi/src/config.ts
+++ b/libs/eventually-openapi/src/config.ts
@@ -1,5 +1,9 @@
-import z from "zod";
+import z, { any } from "zod";
 import { config as target, extend } from "@rotorsoft/eventually";
+
+function fallback<T>(value: T) {
+  return any().transform(() => value);
+}
 
 /**
  * OpenAPI spec options
@@ -12,7 +16,7 @@ export type OAS_UI = (typeof OAS_UIS)[number];
  * Configuration zod schema
  */
 const Schema = z.object({
-  port: z.number().int().min(1000).max(65535),
+  port: z.number().int().min(1000).max(65535).or(fallback('test')),
   oas_ui: z.enum(OAS_UIS)
 });
 
@@ -23,7 +27,7 @@ const { PORT, OAS_UI } = process.env;
  */
 export const config = extend(
   {
-    port: parseInt(PORT || "3000") || 3000,
+    port: parseInt(PORT || "3000"),
     oas_ui: (OAS_UI as OAS_UI) || "SwaggerUI"
   },
   Schema,


### PR DESCRIPTION
#45 did not actually fix that issue.  This PR is an addendum to #45.  It adds a fallback for the PORT config env variable.  If it is invalid in any way it will default to 3000 to pass validation.

Just for clarification my use case requires me to run eventually-express in listen(true) silent mode since the firebase functions framework handles listening in it's own way.  I am not allowed to set an arbitrary value for the PORT env variable because it is reserved when using the firebase-tools CLI, so I needed a way to circumvent this check.