### PR TITLE
fix: pause non-flowing subscription

### DIFF
--- a/libs/eventually-broker/src/cluster/worker.ts
+++ b/libs/eventually-broker/src/cluster/worker.ts
@@ -239,6 +239,9 @@ export const work = async (
                 [],
               position: lastResponse.id
             };
+            if(!retryable) {
+              sub.loop.pause();
+            }
             sendState(state);
             return retryable;
           }
@@ -295,12 +298,20 @@ export const work = async (
         position: sub.state.position
       };
       pump(sub, trigger, sub.state.retryTimeoutSecs * 1000 * sub.retry_count);
+    } else {
+      sub.loop.pause();
     }
   };
 
   const pumpChannel: TriggerCallback = (trigger) => {
     subs.forEach((sub) => {
       sub.retry_count = 0;
+      if(
+        trigger.operation === "REFRESH" ||
+        trigger.operation === "RESTART"
+      ) {
+        sub.loop.resume();
+      }
       pump(sub, trigger);
     });
   };


### PR DESCRIPTION
### Expected Retry Behaviour

1. A retry should be triggered if the consumer replies with a [retriable](https://github.com/Rotorsoft/eventually-monorepo/blob/7c7262311307a268850f40cdfc0889405f33ea1e/libs/eventually-broker/src/cluster/types.ts#L14) error and the `Max Retry` configuration is > 0.
2. No further retries should be triggered once retries are exhausted (`retry_count` == `Max Retry`). i.e. Receiving new event(s) should not trigger a retry.
3. No retry should be triggered if the consumer replies with a non-retriable error.
4. A manual restart resets the retry count, a retry should be triggered (applies to any non-flowing subscription).
5. An automatic refresh (every 10 mins) resets the retry count, a retry should be triggered (applies to any non-flowing subscription).
6. Receiving new event(s) to a non-flowing subscription should not trigger a retry.