### PR TITLE
FIX: All store commits should trigger a drain

### DIFF
--- a/libs/eventually/src/adapters/InMemoryBroker.ts
+++ b/libs/eventually/src/adapters/InMemoryBroker.ts
@@ -71,7 +71,7 @@ export const InMemoryBroker = (options?: {
         if (commit && commit(snapshot)) {
           try {
             const { id, stream, name, metadata, version } = snapshot.event!;
-            return await store().commit(
+            await store().commit(
               stream,
               [
                 {


### PR DESCRIPTION
If a snapshot was created by a commit, the early return prevented a drain from occurring.  This PR removes the early return thus allowing a drain to occur for every commit to the store.