### PR TITLE
fix: mq support distributed concurrent queue processing with guaranteed stream ordering

### DIFF
--- a/libs/eventually-pg/src/PostgresMessageQueue.ts
+++ b/libs/eventually-pg/src/PostgresMessageQueue.ts
@@ -6,6 +6,7 @@ import {
   Messages
 } from "@rotorsoft/eventually";
 import { Pool } from "pg";
+import { pid } from "process";
 import { config } from "./config";
 import { message_queue } from "./seed";
 
@@ -50,65 +51,102 @@ export const PostgresMessageQueue = <M extends Messages>(
     },
 
     /**
-     * Dequeues the oldest available message in the specified stream and passes it to the callback.
-     * It uses a lock mechanism to ensure the message is only processed by one consumer at a time and
-     * also makes sure that no other messages from the same stream can be dequeued while the message
-     * is locked and being processed.
+     * Dequeues and pocesses the oldest message from the queue.  The entire stream is locked
+     * during processing and no other consumers will be able to dequeue messages from the same stream
+     * until the message is processed and deleted from the queue.
+     * @param callback consumer callback that receives the message with storage attributes
+     *   {id, created} and returns a promise<void> or throws an error
+     * @param opts options for dequeuing
+     * @param opts.stream optional stream name, if a stream is not specified then the oldest message from the queue is dequeued.
+     *   If a stream is specified then the oldest message from that stream is dequeued.
+     *   The entire stream of the dequeued message is locked during processing in either case.
+     * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default: 30000)
+     * @returns promise that resolves true when message is successfully processed, resolves false when
+     *   stream/queue is empty or lock cannot be acquired, rejects when message is not processed
      */
-    dequeue: async (callback, { stream }) => {
+    dequeue: async (callback, opts) => {
+      const { stream, leaseMillis = 30000 } = opts;
       const client = await pool.connect();
+      let acquiredMessage:
+        | (Message<M> & { id: number; created: Date })
+        | undefined;
+      let acquisitionTxnActive = false;
+
       try {
+        // First transaction: try to acquire a message
         await client.query("BEGIN");
-
-        // Only acquire advisory lock if stream is defined
-        if (stream !== undefined) {
-          const streamHash = BigInt(
-            Buffer.from(stream).reduce(
-              (acc, byte) => (acc * 31 + byte) & 0x7fffffff,
-              0
-            )
-          );
-
-          const { rows: lockResult } = await client.query(
-            "SELECT pg_try_advisory_xact_lock($1) as acquired",
-            [streamHash]
-          );
-
-          if (!lockResult[0].acquired) {
-            await client.query("ROLLBACK");
-            return false;
-          }
-        }
-
-        // Use FOR UPDATE SKIP LOCKED for unstreamed messages to allow concurrent processing
+        acquisitionTxnActive = true;
         const { rows: next } = await client.query<
           Message<M> & { id: number; created: Date }
         >(
-          `
-          SELECT id, name, stream, data, created
-          FROM "${table}"
-          WHERE stream = $1
-          ORDER BY created ASC, id ASC
-          LIMIT 1
-          ${stream === undefined ? "FOR UPDATE SKIP LOCKED" : "FOR UPDATE"}
-          `,
-          [stream || ""]
+          `WITH lockable_message AS (
+             SELECT t.id, t.name, t.stream, t.data, t.created
+             FROM "${table}" t
+             WHERE t.stream = COALESCE($1, t.stream)
+             AND NOT EXISTS (
+               SELECT 1 FROM "${table}" t2
+               WHERE t2.stream = t.stream
+               AND t2.locked_by IS NOT NULL
+               AND t2.locked_until > NOW()
+             )
+             AND (t.locked_by IS NULL OR t.locked_until <= NOW())
+             ORDER BY t.created ASC, t.id ASC
+             LIMIT 1
+             FOR UPDATE
+           )
+           UPDATE "${table}" t
+           SET locked_by = $2,
+               locked_until = NOW() + ($3 || ' milliseconds')::interval
+           FROM lockable_message l
+           WHERE t.id = l.id
+           RETURNING t.id, t.name, t.stream, t.data, t.created`,
+          [stream || "", pid, leaseMillis]
         );
 
         if (next.length === 0) {
           await client.query("ROLLBACK");
+          acquisitionTxnActive = false;
           return false;
         }
 
-        const message = next[0];
-        await callback(message);
-        await client.query(`DELETE FROM "${table}" WHERE id = $1`, [
-          message.id
-        ]);
         await client.query("COMMIT");
-        return true;
+        acquisitionTxnActive = false;
+        acquiredMessage = next[0];
+
+        // if we got here then we have the stream lock
+        // process and delete the message
+        try {
+          await callback(acquiredMessage);
+
+          // now delete the message, and make sure we still had the stream lock
+          // due to our locking mechanism no other process should have updated this message
+          const result = await client.query(
+            `DELETE FROM "${table}" WHERE id = $1 AND locked_by = $2`,
+            [acquiredMessage.id, pid]
+          );
+
+          return (result.rowCount ?? 0) > 0;
+        } catch (err) {
+          // Try to explicitly release the lock, but don't worry if it fails - locked_until is the fallback
+          try {
+            await client.query(
+              `UPDATE "${table}" 
+               SET locked_by = NULL, 
+                   locked_until = NULL 
+               WHERE id = $1 
+               AND locked_by = $2`,
+              [acquiredMessage.id, pid]
+            );
+          } catch {
+            // Ignore cleanup errors - locked_until is the fallback
+          }
+          throw err;
+        }
       } catch (err) {
-        await client.query("ROLLBACK");
+        // Handle any active transaction
+        if (acquisitionTxnActive) {
+          await client.query("ROLLBACK").catch(() => {});
+        }
         throw err;
       } finally {
         client.release();
@@ -116,12 +154,7 @@ export const PostgresMessageQueue = <M extends Messages>(
     }
   };
 
-  dispose(() => {
-    if (queue.dispose) {
-      return queue.dispose();
-    }
-    return Promise.resolve();
-  });
+  dispose(() => queue.dispose?.());
 
   return queue;
 };

--- a/libs/eventually-pg/src/PostgresMessageQueue.ts
+++ b/libs/eventually-pg/src/PostgresMessageQueue.ts
@@ -1,12 +1,13 @@
 import {
   dispose,
   log,
+  logAdapterCreated,
+  logAdapterDisposed,
   Message,
   MessageQueue,
   Messages
 } from "@rotorsoft/eventually";
 import { Pool } from "pg";
-import { pid } from "process";
 import { config } from "./config";
 import { message_queue } from "./seed";
 
@@ -22,6 +23,8 @@ export const PostgresMessageQueue = <M extends Messages>(
 
     seed: async () => {
       const seed = message_queue(table);
+      log().green().info(`>>> Seeding message queue table: ${table}`);
+      log().gray().info(seed);
       await pool.query(seed);
     },
 
@@ -29,6 +32,10 @@ export const PostgresMessageQueue = <M extends Messages>(
       await pool.query(`DROP TABLE IF EXISTS "${table}"`);
     },
 
+    /**
+     * Enqueues messages into the table.
+     * Each message should be inserted with its stream and a timestamp.
+     */
     enqueue: async (messages) => {
       const N = 3;
       const sql = `
@@ -42,114 +49,53 @@ export const PostgresMessageQueue = <M extends Messages>(
       `;
       const values = messages.flatMap((m) => [
         m.name,
-        m.stream || "",
+        m.stream || "", // empty stream for non-streamed messages
         JSON.stringify(m.data)
       ]);
 
-      await pool.query(sql, values);
       log().green().data("sql:", sql, values);
+      await pool.query(sql, values);
     },
 
     /**
-     * Dequeues and pocesses the oldest message from the queue.  The entire stream is locked
-     * during processing and no other consumers will be able to dequeue messages from the same stream
-     * until the message is processed and deleted from the queue.
-     * @param callback consumer callback that receives the message with storage attributes
-     *   {id, created} and returns a promise<void> or throws an error
-     * @param opts options for dequeuing
-     * @param opts.stream optional stream name, if a stream is not specified then the oldest message from the queue is dequeued.
-     *   If a stream is specified then the oldest message from that stream is dequeued.
-     *   The entire stream of the dequeued message is locked during processing in either case.
-     * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default: 30000)
-     * @returns promise that resolves true when message is successfully processed, resolves false when
-     *   stream/queue is empty or lock cannot be acquired, rejects when message is not processed
+     * Dequeues the oldest available message in the specified stream and passes it to the callback.
+     * It uses a lock mechanism to ensure the message is only processed by one consumer at a time.
      */
-    dequeue: async (callback, opts) => {
-      const { stream, leaseMillis = 30000 } = opts || {
-        stream: undefined,
-        leaseMillis: 30000
-      };
+    dequeue: async (callback, { stream } = {}) => {
       const client = await pool.connect();
-      let acquiredMessage:
-        | (Message<M> & { id: number; created: Date })
-        | undefined;
-      let acquisitionTxnActive = false;
-
       try {
-        // First transaction: try to acquire a message
         await client.query("BEGIN");
-        acquisitionTxnActive = true;
+
+        // select and lock the next message in the queue
         const { rows: next } = await client.query<
           Message<M> & { id: number; created: Date }
         >(
-          `WITH lockable_message AS (
-             SELECT t.id, t.name, t.stream, t.data, t.created
-             FROM "${table}" t
-             WHERE ($1::text IS NULL OR t.stream = $1::text)
-             AND NOT EXISTS (
-               SELECT 1 FROM "${table}" t2
-               WHERE t2.stream = t.stream
-               AND t2.locked_by IS NOT NULL
-               AND t2.locked_until > NOW()
-             )
-             AND (t.locked_by IS NULL OR t.locked_until <= NOW())
-             ORDER BY t.created ASC, t.id ASC
-             LIMIT 1
-             FOR UPDATE
-           )
-           UPDATE "${table}" t
-           SET locked_by = $2::integer,
-               locked_until = NOW() + ($3::integer || ' milliseconds')::interval
-           FROM lockable_message l
-           WHERE t.id = l.id
-           RETURNING t.id, t.name, t.stream, t.data, t.created`,
-          [stream || null, pid, leaseMillis]
+          `
+          SELECT * FROM "${table}"
+          WHERE stream = $1
+          ORDER BY created ASC LIMIT 1
+          FOR UPDATE SKIP LOCKED
+        `,
+          [stream]
         );
-
         if (next.length === 0) {
+          log().yellow().trace(`No messages available for stream: ${stream}`);
           await client.query("ROLLBACK");
-          acquisitionTxnActive = false;
           return false;
         }
 
+        // process the message using the provided callback
+        const message = next[0];
+        await callback(message);
+        // delete message from the queue on success
+        await client.query(`DELETE FROM "${table}" WHERE id = $1`, [
+          message.id
+        ]);
         await client.query("COMMIT");
-        acquisitionTxnActive = false;
-        acquiredMessage = next[0];
-
-        // if we got here then we have the stream lock
-        // process and delete the message
-        try {
-          await callback(acquiredMessage);
-
-          // now delete the message, and make sure we still had the stream lock
-          // due to our locking mechanism no other process should have updated this message
-          const result = await client.query(
-            `DELETE FROM "${table}" WHERE id = $1 AND locked_by = $2`,
-            [acquiredMessage.id, pid]
-          );
-
-          return (result.rowCount ?? 0) > 0;
-        } catch (err) {
-          // Try to explicitly release the lock, but don't worry if it fails - locked_until is the fallback
-          try {
-            await client.query(
-              `UPDATE "${table}" 
-               SET locked_by = NULL, 
-                   locked_until = NULL 
-               WHERE id = $1 
-               AND locked_by = $2`,
-              [acquiredMessage.id, pid]
-            );
-          } catch {
-            // Ignore cleanup errors - locked_until is the fallback
-          }
-          throw err;
-        }
+        return true;
       } catch (err) {
-        // Handle any active transaction
-        if (acquisitionTxnActive) {
-          await client.query("ROLLBACK").catch(() => {});
-        }
+        await client.query("ROLLBACK");
+        log().red().error(err);
         throw err;
       } finally {
         client.release();
@@ -157,7 +103,14 @@ export const PostgresMessageQueue = <M extends Messages>(
     }
   };
 
-  dispose(() => queue.dispose?.());
+  logAdapterCreated(queue.name);
+  dispose(() => {
+    if (queue.dispose) {
+      logAdapterDisposed(queue.name);
+      return queue.dispose();
+    }
+    return Promise.resolve();
+  });
 
   return queue;
 };

--- a/libs/eventually-pg/src/PostgresOrderedMessageQueue.ts
+++ b/libs/eventually-pg/src/PostgresOrderedMessageQueue.ts
@@ -1,0 +1,172 @@
+import {
+  dispose,
+  log,
+  logAdapterCreated,
+  logAdapterDisposed,
+  Message,
+  MessageQueue,
+  Messages
+} from "@rotorsoft/eventually";
+import { Pool } from "pg";
+import { pid } from "process";
+import { config } from "./config";
+import { ordered_message_queue } from "./seed";
+
+export const PostgresOrderedMessageQueue = <M extends Messages>(
+  table: string
+): MessageQueue<M> => {
+  const pool = new Pool(config.pg);
+  const queue: MessageQueue<M> = {
+    name: `PostgresOrderedMessageQueue:${table}`,
+    dispose: async () => {
+      await pool.end();
+    },
+
+    seed: async () => {
+      const seed = ordered_message_queue(table);
+      await pool.query(seed);
+    },
+
+    drop: async (): Promise<void> => {
+      await pool.query(`DROP TABLE IF EXISTS "${table}"`);
+    },
+
+    enqueue: async (messages) => {
+      const N = 3;
+      const sql = `
+        INSERT INTO "${table}" (name, stream, data)
+        VALUES ${messages
+          .map(
+            (_, i) =>
+              `(${[...Array(N)].map((_, j) => `$${i * N + j + 1}`).join(", ")})`
+          )
+          .join(", ")}
+      `;
+      const values = messages.flatMap((m) => [
+        m.name,
+        m.stream || "",
+        JSON.stringify(m.data)
+      ]);
+
+      await pool.query(sql, values);
+      log().green().data("sql:", sql, values);
+    },
+
+    /**
+     * Dequeues and pocesses the oldest message from the queue.  The entire stream is locked
+     * during processing and no other consumers will be able to dequeue messages from the same stream
+     * until the message is processed and deleted from the queue.
+     * @param callback consumer callback that receives the message with storage attributes
+     *   {id, created} and returns a promise<void> or throws an error
+     * @param opts options for dequeuing
+     * @param opts.stream optional stream name, if a stream is not specified then the oldest message from the queue is dequeued.
+     *   If a stream is specified then the oldest message from that stream is dequeued.
+     *   The entire stream of the dequeued message is locked during processing in either case.
+     * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default: 30000)
+     * @returns promise that resolves true when message is successfully processed, resolves false when
+     *   stream/queue is empty or lock cannot be acquired, rejects when message is not processed
+     */
+    dequeue: async (callback, opts) => {
+      const { stream, leaseMillis = 30000 } = opts || {
+        stream: undefined,
+        leaseMillis: 30000
+      };
+      const client = await pool.connect();
+      let acquiredMessage:
+        | (Message<M> & { id: number; created: Date })
+        | undefined;
+      let acquisitionTxnActive = false;
+
+      try {
+        // First transaction: try to acquire a message
+        await client.query("BEGIN");
+        acquisitionTxnActive = true;
+        const { rows: next } = await client.query<
+          Message<M> & { id: number; created: Date }
+        >(
+          `WITH lockable_message AS (
+             SELECT t.id, t.name, t.stream, t.data, t.created
+             FROM "${table}" t
+             WHERE ($1::text IS NULL OR t.stream = $1::text)
+             AND NOT EXISTS (
+               SELECT 1 FROM "${table}" t2
+               WHERE t2.stream = t.stream
+               AND t2.locked_by IS NOT NULL
+               AND t2.locked_until > NOW()
+             )
+             AND (t.locked_by IS NULL OR t.locked_until <= NOW())
+             ORDER BY t.created ASC, t.id ASC
+             LIMIT 1
+             FOR UPDATE
+           )
+           UPDATE "${table}" t
+           SET locked_by = $2::integer,
+               locked_until = NOW() + ($3::integer || ' milliseconds')::interval
+           FROM lockable_message l
+           WHERE t.id = l.id
+           RETURNING t.id, t.name, t.stream, t.data, t.created`,
+          [stream || null, pid, leaseMillis]
+        );
+
+        if (next.length === 0) {
+          await client.query("ROLLBACK");
+          acquisitionTxnActive = false;
+          return false;
+        }
+
+        await client.query("COMMIT");
+        acquisitionTxnActive = false;
+        acquiredMessage = next[0];
+
+        // if we got here then we have the stream lock
+        // process and delete the message
+        try {
+          await callback(acquiredMessage);
+
+          // now delete the message, and make sure we still had the stream lock
+          // due to our locking mechanism no other process should have updated this message
+          const result = await client.query(
+            `DELETE FROM "${table}" WHERE id = $1 AND locked_by = $2`,
+            [acquiredMessage.id, pid]
+          );
+
+          return (result.rowCount ?? 0) > 0;
+        } catch (err) {
+          // Try to explicitly release the lock, but don't worry if it fails - locked_until is the fallback
+          try {
+            await client.query(
+              `UPDATE "${table}" 
+               SET locked_by = NULL, 
+                   locked_until = NULL 
+               WHERE id = $1 
+               AND locked_by = $2`,
+              [acquiredMessage.id, pid]
+            );
+          } catch {
+            // Ignore cleanup errors - locked_until is the fallback
+          }
+          throw err;
+        }
+      } catch (err) {
+        // Handle any active transaction
+        if (acquisitionTxnActive) {
+          await client.query("ROLLBACK").catch(() => {});
+        }
+        throw err;
+      } finally {
+        client.release();
+      }
+    }
+  };
+
+  logAdapterCreated(queue.name);
+  dispose(() => {
+    if (queue.dispose) {
+      logAdapterDisposed(queue.name);
+      return queue.dispose();
+    }
+    return Promise.resolve();
+  });
+
+  return queue;
+};

--- a/libs/eventually-pg/src/__tests__/message-queue.spec.ts
+++ b/libs/eventually-pg/src/__tests__/message-queue.spec.ts
@@ -1,4 +1,4 @@
-import { dispose, Message, sleep } from "@rotorsoft/eventually";
+import { dispose, log, Message, sleep } from "@rotorsoft/eventually";
 import { PostgresMessageQueue } from "..";
 
 const table = "message_queue_test";
@@ -87,42 +87,59 @@ describe("message queue", () => {
     );
 
     // try to immediately dequeue again with successful handler
-    expect(await mq.dequeue(async () => {}, { stream: "error-test" })).toBe(true)
+    expect(await mq.dequeue(async () => {}, { stream: "error-test" })).toBe(
+      true
+    );
   });
 
   it("should handle concurrent dequeue attempts correctly", async () => {
     // Enqueue multiple messages
     await mq.enqueue([
       { name: "concurrent", stream: "concurrent-test", data: { value: "1" } },
-      { name: "concurrent", stream: "concurrent-test", data: { value: "2" } },
-      { name: "concurrent", stream: "concurrent-test", data: { value: "3" } }
+      { name: "concurrent", stream: "concurrent-test-2", data: { value: "2" } },
+      { name: "concurrent", stream: "concurrent-test-3", data: { value: "3" } }
     ]);
 
     const processedMessages = new Set<string>();
     const processingTimes = new Map<string, number>();
+    const processingOrder = [] as string[];
 
     // Create a handler that simulates long-running processing
     const handler = async (message: Message) => {
       const value = message.data.value as string;
-      
-      // Ensure message wasn't processed before
-      expect(processedMessages.has(value)).toBeFalsy();
-      
+      const stream = message.stream;
+
+      log().info(`Starting to process message ${value} from stream ${stream}`);
+
       // Record processing start time
-      processingTimes.set(value, Date.now());
-      
+      const startTime = Date.now();
+      processingTimes.set(value, startTime);
+
       // Simulate processing time
       await sleep(500);
-      
+
+      log().info(`Finished processing message ${value} from stream ${stream}`);
+
+      // Ensure message wasn't processed before
+      if (processedMessages.has(value)) {
+        throw new Error(`Message ${value} was processed more than once!`);
+      }
+
       processedMessages.add(value);
+      processingOrder.push(value);
     };
 
     // Run multiple dequeue operations concurrently
-    await Promise.all([
+    const results = await Promise.all([
       mq.dequeue(handler, { stream: "concurrent-test" }),
-      mq.dequeue(handler, { stream: "concurrent-test" }),
-      mq.dequeue(handler, { stream: "concurrent-test" })
+      mq.dequeue(handler, { stream: "concurrent-test-2" }),
+      mq.dequeue(handler, { stream: "concurrent-test-3" })
     ]);
+
+    // Log the results
+    log().info("Processing order:", processingOrder);
+    log().info("Processing times:", Object.fromEntries(processingTimes));
+    log().info("Dequeue results:", results);
 
     // Verify each message was processed exactly once
     expect(processedMessages.size).toBe(3);
@@ -130,10 +147,16 @@ describe("message queue", () => {
     expect(processedMessages).toContain("2");
     expect(processedMessages).toContain("3");
 
+    // Verify all dequeues were successful
+    expect(results.filter((r) => r === true).length).toBe(3);
+
     // Verify messages were processed in parallel
     const times = Array.from(processingTimes.values());
     const maxTimeDiff = Math.max(...times) - Math.min(...times);
-    expect(maxTimeDiff).toBeLessThan(100); // Should start within 100ms of each other
+    log().info(
+      `Max time difference between message processing: ${maxTimeDiff}ms`
+    );
+    expect(maxTimeDiff).toBeLessThan(100);
   });
 
   it("should maintain message order within a single consumer", async () => {
@@ -150,12 +173,21 @@ describe("message queue", () => {
     };
 
     // Process all messages sequentially
-    await mq.dequeue(handler, { stream: "order-test" });
-    await mq.dequeue(handler, { stream: "order-test" });
-    await mq.dequeue(handler, { stream: "order-test" });
+    const result1 = await mq.dequeue(handler, { stream: "order-test" });
+    const result2 = await mq.dequeue(handler, { stream: "order-test" });
+    const result3 = await mq.dequeue(handler, { stream: "order-test" });
+
+    // Verify all dequeues were successful
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(result3).toBe(true);
 
     // Verify messages were processed in order
     expect(processedOrder).toEqual(["1", "2", "3"]);
+
+    // Verify no more messages are available
+    const emptyResult = await mq.dequeue(handler, { stream: "order-test" });
+    expect(emptyResult).toBe(false);
   });
 
   it("should handle transaction rollback on error correctly", async () => {
@@ -169,7 +201,7 @@ describe("message queue", () => {
       throw new Error("Simulated failure");
     };
 
-    const successHandler = async () => {
+    const successHandler = () => {
       attempts++;
       return Promise.resolve();
     };
@@ -184,19 +216,453 @@ describe("message queue", () => {
       mq.dequeue(failHandler, { stream: "rollback-test" })
     ).rejects.toThrow("Simulated failure");
     expect(attempts).toBe(2); // Handler should have been called twice
-    
+
     // should still be able to dequeue and process successfully
-    await expect(
-      mq.dequeue(successHandler, { stream: "rollback-test" })
-    ).resolves.toBe(true);
+    const successResult = await mq.dequeue(successHandler, {
+      stream: "rollback-test"
+    });
+    expect(successResult).toBe(true);
     expect(attempts).toBe(3);
 
     //should not dequeue anything since stream should be empty
-    await expect(
-      mq.dequeue(successHandler, { stream: "rollback-test" })
-    ).resolves.toBe(false);
-    // shuld still be 3 attempts since we processed one message
+    const emptyResult = await mq.dequeue(successHandler, {
+      stream: "rollback-test"
+    });
+    expect(emptyResult).toBe(false);
+    // should still be 3 attempts since we processed one message
     expect(attempts).toBe(3);
-  
+  });
+
+  it("should prevent processing multiple messages from same stream concurrently", async () => {
+    // Enqueue multiple messages for the same stream
+    await mq.enqueue([
+      { name: "stream-lock", stream: "stream-lock-test", data: { value: "1" } },
+      { name: "stream-lock", stream: "stream-lock-test", data: { value: "2" } },
+      { name: "stream-lock", stream: "stream-lock-test", data: { value: "3" } }
+    ]);
+
+    let currentlyProcessing = false;
+    const processedMessages: string[] = [];
+    const processingStarts: { value: string; time: number }[] = [];
+    const processingEnds: { value: string; time: number }[] = [];
+
+    // Create a handler that tracks concurrent processing
+    const handler = async (message: Message): Promise<void> => {
+      const value = message.data.value as string;
+      const startTime = Date.now();
+
+      log().info(`Attempting to process message ${value}`);
+      processingStarts.push({ value, time: startTime });
+
+      // Assert that no other message from this stream is being processed
+      if (currentlyProcessing) {
+        throw new Error(`Concurrent processing detected for message ${value}`);
+      }
+
+      currentlyProcessing = true;
+
+      // Simulate some processing time
+      await sleep(500);
+
+      processedMessages.push(value);
+      currentlyProcessing = false;
+
+      const endTime = Date.now();
+      processingEnds.push({ value, time: endTime });
+      log().info(`Finished processing message ${value}`);
+    };
+
+    // Try to process messages concurrently
+    const dequeuePromises = [
+      mq.dequeue(handler, { stream: "stream-lock-test" }),
+      mq.dequeue(handler, { stream: "stream-lock-test" }),
+      mq.dequeue(handler, { stream: "stream-lock-test" })
+    ];
+
+    const results = await Promise.all(dequeuePromises);
+
+    // Log processing details
+    log().info("Processed messages in order:", processedMessages);
+    log().info("Processing starts:", processingStarts);
+    log().info("Processing ends:", processingEnds);
+    log().info("Dequeue results:", results);
+
+    // Only one dequeue operation should succeed
+    const successCount = results.filter((result) => result === true).length;
+    expect(successCount).toBe(1);
+
+    // Only one message should be processed
+    expect(processedMessages.length).toBe(1);
+    expect(processedMessages[0]).toBe("1"); // Should be the first message
+
+    // Now we should be able to process the next message
+    const result2 = await mq.dequeue(handler, { stream: "stream-lock-test" });
+    expect(result2).toBe(true);
+    expect(processedMessages.length).toBe(2);
+    expect(processedMessages[1]).toBe("2"); // Should be the second message
+
+    // And the final message
+    const result3 = await mq.dequeue(handler, { stream: "stream-lock-test" });
+    expect(result3).toBe(true);
+    expect(processedMessages.length).toBe(3);
+    expect(processedMessages[2]).toBe("3"); // Should be the third message
+
+    // Verify messages were processed in order
+    expect(processedMessages).toEqual(["1", "2", "3"]);
+
+    // Verify no more messages are available
+    const emptyResult = await mq.dequeue(handler, {
+      stream: "stream-lock-test"
+    });
+    expect(emptyResult).toBe(false);
+  });
+
+  it("should handle unstreamed messages correctly", async () => {
+    // Enqueue multiple unstreamed messages
+    await mq.enqueue([
+      { name: "unstreamed", data: { value: "1" } },
+      { name: "unstreamed", data: { value: "2" } },
+      { name: "unstreamed", data: { value: "3" } },
+      { name: "unstreamed", data: { value: "4" } }
+    ]);
+
+    const processedMessages: string[] = [];
+    const processing = new Set<string>();
+    let maxConcurrent = 0;
+    const processingOrder: string[] = [];
+
+    // Create a promise that resolves when first message starts processing
+    let firstProcessingResolve: () => void;
+    const firstProcessingPromise = new Promise<void>((resolve) => {
+      firstProcessingResolve = resolve;
+    });
+
+    // Try to process multiple messages concurrently
+    const results = await Promise.all([
+      mq.dequeue(
+        async (message) => {
+          const value = message.data.value as string;
+          processing.add(value);
+          maxConcurrent = Math.max(maxConcurrent, processing.size);
+          processingOrder.push(`start-${value}`);
+
+          if (processing.size === 1) {
+            firstProcessingResolve();
+            // First message waits longer
+            await sleep(100);
+          } else {
+            // Subsequent messages process faster
+            await sleep(50);
+          }
+
+          processingOrder.push(`end-${value}`);
+          processing.delete(value);
+          processedMessages.push(value);
+        },
+        { stream: undefined }
+      ),
+
+      // Wait for first message to start processing before starting others
+      (async () => {
+        await firstProcessingPromise;
+        return mq.dequeue(
+          async (message) => {
+            const value = message.data.value as string;
+            processing.add(value);
+            maxConcurrent = Math.max(maxConcurrent, processing.size);
+            processingOrder.push(`start-${value}`);
+            await sleep(50);
+            processingOrder.push(`end-${value}`);
+            processing.delete(value);
+            processedMessages.push(value);
+          },
+          { stream: undefined }
+        );
+      })(),
+
+      (async () => {
+        await firstProcessingPromise;
+        return mq.dequeue(
+          async (message) => {
+            const value = message.data.value as string;
+            processing.add(value);
+            maxConcurrent = Math.max(maxConcurrent, processing.size);
+            processingOrder.push(`start-${value}`);
+            await sleep(50);
+            processingOrder.push(`end-${value}`);
+            processing.delete(value);
+            processedMessages.push(value);
+          },
+          { stream: undefined }
+        );
+      })()
+    ]);
+
+    // Verify concurrent processing occurred
+    expect(maxConcurrent).toBeGreaterThan(1);
+
+    // Should have processed multiple messages
+    // eslint-disable-next-line require-await
+    const successCount = results.filter((r) => r === true).length;
+    expect(successCount).toBeGreaterThan(1);
+
+    // Process remaining message
+    while (processedMessages.length < 4) {
+      const result = await mq.dequeue(
+        (message) => {
+          const value = message.data.value as string;
+          processingOrder.push(`start-${value}`);
+          processingOrder.push(`end-${value}`);
+          processedMessages.push(value);
+          return Promise.resolve();
+        },
+        { stream: undefined }
+      );
+      expect(result).toBe(true);
+    }
+
+    // Verify all messages were processed
+    expect(processedMessages.length).toBe(4);
+    expect(new Set(processedMessages)).toEqual(new Set(["1", "2", "3", "4"]));
+
+    // Verify concurrent processing by checking processing order
+    const startIndices = processingOrder
+      .map((entry, index) => (entry.startsWith("start-") ? index : -1))
+      .filter((index) => index !== -1);
+
+    const endIndices = processingOrder
+      .map((entry, index) => (entry.startsWith("end-") ? index : -1))
+      .filter((index) => index !== -1);
+
+    // Verify that at least one message started processing before another finished
+    const hasOverlap = startIndices.some(
+      (startIdx, i) => i > 0 && startIdx < endIndices[i - 1]
+    );
+    expect(hasOverlap).toBe(true);
+
+    // Verify no more messages
+    const emptyResult = await mq.dequeue(async () => {}, { stream: undefined });
+    expect(emptyResult).toBe(false);
+  });
+
+  it("should maintain message order within streams when processing multiple streams concurrently", async () => {
+    // Enqueue interleaved messages from different streams
+    await mq.enqueue([
+      { name: "multi", stream: "stream-1", data: { value: "1-1" } },
+      { name: "multi", stream: "stream-2", data: { value: "2-1" } },
+      { name: "multi", stream: "stream-1", data: { value: "1-2" } },
+      { name: "multi", stream: "stream-2", data: { value: "2-2" } },
+      { name: "multi", stream: "stream-1", data: { value: "1-3" } },
+      { name: "multi", stream: "stream-2", data: { value: "2-3" } },
+      { name: "multi", stream: "stream-3", data: { value: "3-1" } },
+      { name: "multi", stream: "stream-1", data: { value: "1-4" } },
+      { name: "multi", stream: "stream-3", data: { value: "3-2" } },
+      { name: "multi", stream: "stream-2", data: { value: "2-4" } }
+    ]);
+
+    const processedByStream: Record<string, string[]> = {
+      "stream-1": [],
+      "stream-2": [],
+      "stream-3": []
+    };
+
+    // Process all streams concurrently multiple times
+    const processingRounds = 4; // Enough rounds to process all messages
+    for (let i = 0; i < processingRounds; i++) {
+      await Promise.all([
+        mq.dequeue(
+          async (message) => {
+            await sleep(Math.random() * 50); // Random processing time
+            const stream = message.stream || "";
+            processedByStream[stream].push(message.data.value as string);
+          },
+          { stream: "stream-1" }
+        ),
+        mq.dequeue(
+          async (message) => {
+            await sleep(Math.random() * 50); // Random processing time
+            const stream = message.stream || "";
+            processedByStream[stream].push(message.data.value as string);
+          },
+          { stream: "stream-2" }
+        ),
+        mq.dequeue(
+          async (message) => {
+            await sleep(Math.random() * 50); // Random processing time
+            const stream = message.stream || "";
+            processedByStream[stream].push(message.data.value as string);
+          },
+          { stream: "stream-3" }
+        )
+      ]);
+    }
+
+    // Verify order within each stream
+    expect(processedByStream["stream-1"]).toEqual(["1-1", "1-2", "1-3", "1-4"]);
+    expect(processedByStream["stream-2"]).toEqual(["2-1", "2-2", "2-3", "2-4"]);
+    expect(processedByStream["stream-3"]).toEqual(["3-1", "3-2"]);
+
+    // Verify no more messages in any stream
+    const results = await Promise.all([
+      mq.dequeue(async () => {}, { stream: "stream-1" }),
+      mq.dequeue(async () => {}, { stream: "stream-2" }),
+      mq.dequeue(async () => {}, { stream: "stream-3" })
+    ]);
+    expect(results.every((r) => r === false)).toBe(true);
+  });
+
+  it("should correctly handle a mix of streamed and unstreamed messages", async () => {
+    // Enqueue mix of streamed and unstreamed messages
+    await mq.enqueue([
+      { name: "mixed", stream: "stream-1", data: { value: "1-1" } },
+      { name: "mixed", data: { value: "u-1" } },
+      { name: "mixed", stream: "stream-2", data: { value: "2-1" } },
+      { name: "mixed", data: { value: "u-2" } },
+      { name: "mixed", stream: "stream-1", data: { value: "1-2" } },
+      { name: "mixed", stream: "stream-2", data: { value: "2-2" } },
+      { name: "mixed", data: { value: "u-3" } },
+      { name: "mixed", stream: "stream-1", data: { value: "1-3" } },
+      { name: "mixed", data: { value: "u-4" } },
+      { name: "mixed", stream: "stream-2", data: { value: "2-3" } }
+    ]);
+
+    const processedByStream: Record<string, string[]> = {
+      "stream-1": [],
+      "stream-2": [],
+      unstreamed: []
+    };
+
+    // Track concurrent processing
+    const activeProcessing = new Set<string>();
+    let streamProcessingOverlap = false;
+    let hadConcurrentUnstreamed = false;
+
+    // Promises to coordinate unstreamed message processing
+    let firstUnstreamedStarted = false;
+    let firstUnstreamedResolve: (x: unknown) => void;
+
+    const firstUnstreamedProcessing = new Promise((resolve) => {
+      firstUnstreamedResolve = resolve;
+    });
+
+    // Process streamed and unstreamed messages concurrently
+    await Promise.all([
+      // First unstreamed processor - start this first
+      mq.dequeue(
+        async (message) => {
+          firstUnstreamedStarted = true;
+          activeProcessing.add("unstreamed");
+          processedByStream["unstreamed"].push(message.data.value as string);
+          await sleep(100); // Longer sleep to ensure overlap opportunity
+          firstUnstreamedResolve(undefined);
+          activeProcessing.delete("unstreamed");
+        },
+        { stream: undefined }
+      ),
+
+      // Wait briefly to ensure first unstreamed has started
+      (async () => {
+        await sleep(50);
+        return mq.dequeue(
+          async (message) => {
+            if (firstUnstreamedStarted && activeProcessing.has("unstreamed")) {
+              hadConcurrentUnstreamed = true;
+            }
+            activeProcessing.add("unstreamed");
+            processedByStream["unstreamed"].push(message.data.value as string);
+            await sleep(10);
+            activeProcessing.delete("unstreamed");
+          },
+          { stream: undefined }
+        );
+      })(),
+
+      // Stream processors can start whenever
+      mq.dequeue(
+        async (message) => {
+          const stream = "stream-1";
+          if (activeProcessing.has(stream)) streamProcessingOverlap = true;
+          activeProcessing.add(stream);
+          await sleep(10);
+          activeProcessing.delete(stream);
+          processedByStream[stream].push(message.data.value as string);
+        },
+        { stream: "stream-1" }
+      ),
+
+      mq.dequeue(
+        async (message) => {
+          const stream = "stream-2";
+          if (activeProcessing.has(stream)) streamProcessingOverlap = true;
+          activeProcessing.add(stream);
+          await sleep(10);
+          activeProcessing.delete(stream);
+          processedByStream[stream].push(message.data.value as string);
+        },
+        { stream: "stream-2" }
+      )
+    ]);
+
+    // Wait for first unstreamed to complete
+    await firstUnstreamedProcessing;
+
+    // Process remaining messages
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const streamResults = await Promise.all([
+        mq.dequeue(
+          async (message) => {
+            const stream = "stream-1";
+            if (activeProcessing.has(stream)) streamProcessingOverlap = true;
+            activeProcessing.add(stream);
+            await sleep(10);
+            activeProcessing.delete(stream);
+            processedByStream[stream].push(message.data.value as string);
+          },
+          { stream: "stream-1" }
+        ),
+        mq.dequeue(
+          async (message) => {
+            const stream = "stream-2";
+            if (activeProcessing.has(stream)) streamProcessingOverlap = true;
+            activeProcessing.add(stream);
+            await sleep(10);
+            activeProcessing.delete(stream);
+            processedByStream[stream].push(message.data.value as string);
+          },
+          { stream: "stream-2" }
+        ),
+        mq.dequeue(
+          async (message) => {
+            if (activeProcessing.has("unstreamed")) {
+              hadConcurrentUnstreamed = true;
+            }
+            activeProcessing.add("unstreamed");
+            processedByStream["unstreamed"].push(message.data.value as string);
+            await sleep(10);
+            activeProcessing.delete("unstreamed");
+          },
+          { stream: undefined }
+        )
+      ]);
+
+      if (streamResults.every((r) => r === false)) break;
+    }
+
+    // Verify order within streamed messages
+    expect(processedByStream["stream-1"]).toEqual(["1-1", "1-2", "1-3"]);
+    expect(processedByStream["stream-2"]).toEqual(["2-1", "2-2", "2-3"]);
+
+    // Verify all unstreamed messages were processed
+    expect(processedByStream["unstreamed"].length).toBe(4);
+    expect(new Set(processedByStream["unstreamed"])).toEqual(
+      new Set(["u-1", "u-2", "u-3", "u-4"])
+    );
+
+    // Verify concurrent processing of unstreamed messages occurred
+    expect(hadConcurrentUnstreamed).toBe(true);
+
+    // Verify no concurrent processing within streams
+    expect(streamProcessingOverlap).toBe(false);
   });
 });

--- a/libs/eventually-pg/src/__tests__/message-queue.spec.ts
+++ b/libs/eventually-pg/src/__tests__/message-queue.spec.ts
@@ -1,4 +1,4 @@
-import { dispose, log, Message, sleep } from "@rotorsoft/eventually";
+import { dispose, Message, sleep } from "@rotorsoft/eventually";
 import { PostgresMessageQueue } from "..";
 
 const table = "message_queue_test";
@@ -14,152 +14,7 @@ describe("message queue", () => {
     await dispose()();
   });
 
-  it("should enqueue and dequeue", async () => {
-    await mq.enqueue([{ name: "a", stream: "test", data: { value: "1" } }]);
-    await mq.enqueue([
-      { name: "a", stream: "test", data: { value: "2" } },
-      { name: "a", stream: "test", data: { value: "3" } },
-      { name: "a", stream: "test", data: { value: "4" } }
-    ]);
-    await mq.enqueue([{ name: "a", stream: "test", data: { value: "5" } }]);
-
-    // should dequeue in order
-    const messages: Message[] = [];
-    await mq.dequeue(
-      (message) => {
-        messages.push(message);
-        return Promise.resolve();
-      },
-      { stream: "test" }
-    );
-    expect(messages.length).toBe(1);
-
-    // should not dequeue if stream is locked
-    await Promise.all([
-      // should lock the stream for 1 second
-      mq.dequeue(
-        async (message) => {
-          await sleep(1000);
-          messages.push(message);
-        },
-        { stream: "test" }
-      ),
-      // the stream should be locked for 1 second, thus should not dequeue
-      async () => {
-        await sleep(300);
-        await mq.dequeue(
-          async (message) => {
-            messages.push(message);
-            return Promise.resolve();
-          },
-          { stream: "test" }
-        );
-        expect(messages.length).toBe(1);
-      }
-    ]);
-
-    // should be able to dequeue again
-    await mq.dequeue(
-      (message) => {
-        messages.push(message);
-        return Promise.resolve();
-      },
-      { stream: "test" }
-    );
-    expect(messages.length).toBe(3);
-  });
-
-  it("should propagate handler errors to dequeue caller", async () => {
-    // Enqueue a test message
-    await mq.enqueue([
-      { name: "test", stream: "error-test", data: { value: "error" } }
-    ]);
-
-    // Create a handler that throws an error
-    const errorMessage = "Test error from handler";
-    const handler = () => {
-      throw new Error(errorMessage);
-    };
-
-    // Verify that the error is propagated
-    await expect(mq.dequeue(handler, { stream: "error-test" })).rejects.toThrow(
-      errorMessage
-    );
-
-    // try to immediately dequeue again with successful handler
-    expect(await mq.dequeue(async () => {}, { stream: "error-test" })).toBe(
-      true
-    );
-  });
-
-  it("should handle concurrent dequeue attempts correctly", async () => {
-    // Enqueue multiple messages
-    await mq.enqueue([
-      { name: "concurrent", stream: "concurrent-test", data: { value: "1" } },
-      { name: "concurrent", stream: "concurrent-test-2", data: { value: "2" } },
-      { name: "concurrent", stream: "concurrent-test-3", data: { value: "3" } }
-    ]);
-
-    const processedMessages = new Set<string>();
-    const processingTimes = new Map<string, number>();
-    const processingOrder = [] as string[];
-
-    // Create a handler that simulates long-running processing
-    const handler = async (message: Message) => {
-      const value = message.data.value as string;
-      const stream = message.stream;
-
-      log().info(`Starting to process message ${value} from stream ${stream}`);
-
-      // Record processing start time
-      const startTime = Date.now();
-      processingTimes.set(value, startTime);
-
-      // Simulate processing time
-      await sleep(500);
-
-      log().info(`Finished processing message ${value} from stream ${stream}`);
-
-      // Ensure message wasn't processed before
-      if (processedMessages.has(value)) {
-        throw new Error(`Message ${value} was processed more than once!`);
-      }
-
-      processedMessages.add(value);
-      processingOrder.push(value);
-    };
-
-    // Run multiple dequeue operations concurrently
-    const results = await Promise.all([
-      mq.dequeue(handler, { stream: "concurrent-test" }),
-      mq.dequeue(handler, { stream: "concurrent-test-2" }),
-      mq.dequeue(handler, { stream: "concurrent-test-3" })
-    ]);
-
-    // Log the results
-    log().info("Processing order:", processingOrder);
-    log().info("Processing times:", Object.fromEntries(processingTimes));
-    log().info("Dequeue results:", results);
-
-    // Verify each message was processed exactly once
-    expect(processedMessages.size).toBe(3);
-    expect(processedMessages).toContain("1");
-    expect(processedMessages).toContain("2");
-    expect(processedMessages).toContain("3");
-
-    // Verify all dequeues were successful
-    expect(results.filter((r) => r === true).length).toBe(3);
-
-    // Verify messages were processed in parallel
-    const times = Array.from(processingTimes.values());
-    const maxTimeDiff = Math.max(...times) - Math.min(...times);
-    log().info(
-      `Max time difference between message processing: ${maxTimeDiff}ms`
-    );
-    expect(maxTimeDiff).toBeLessThan(100);
-  });
-
-  it("should maintain message order within a single consumer", async () => {
+  it("should enqueue and dequeue in order", async () => {
     await mq.enqueue([
       { name: "order", stream: "order-test", data: { value: "1" } },
       { name: "order", stream: "order-test", data: { value: "2" } },
@@ -177,20 +32,17 @@ describe("message queue", () => {
     const result2 = await mq.dequeue(handler, { stream: "order-test" });
     const result3 = await mq.dequeue(handler, { stream: "order-test" });
 
-    // Verify all dequeues were successful
     expect(result1).toBe(true);
     expect(result2).toBe(true);
     expect(result3).toBe(true);
-
-    // Verify messages were processed in order
     expect(processedOrder).toEqual(["1", "2", "3"]);
 
-    // Verify no more messages are available
+    // Verify no more messages
     const emptyResult = await mq.dequeue(handler, { stream: "order-test" });
     expect(emptyResult).toBe(false);
   });
 
-  it("should handle transaction rollback on error correctly", async () => {
+  it("should handle transaction rollback on error", async () => {
     await mq.enqueue([
       { name: "rollback", stream: "rollback-test", data: { value: "1" } }
     ]);
@@ -201,468 +53,147 @@ describe("message queue", () => {
       throw new Error("Simulated failure");
     };
 
+    // First attempt should fail and rollback
+    await expect(
+      mq.dequeue(failHandler, { stream: "rollback-test" })
+    ).rejects.toThrow("Simulated failure");
+
+    // Message should be available for retry
     const successHandler = () => {
       attempts++;
       return Promise.resolve();
     };
+    const result = await mq.dequeue(successHandler, { stream: "rollback-test" });
+    expect(result).toBe(true);
+    expect(attempts).toBe(2);
 
-    // First attempt should fail
-    await expect(
-      mq.dequeue(failHandler, { stream: "rollback-test" })
-    ).rejects.toThrow("Simulated failure");
-
-    // Message should be immediately available for retry
-    await expect(
-      mq.dequeue(failHandler, { stream: "rollback-test" })
-    ).rejects.toThrow("Simulated failure");
-    expect(attempts).toBe(2); // Handler should have been called twice
-
-    // should still be able to dequeue and process successfully
-    const successResult = await mq.dequeue(successHandler, {
-      stream: "rollback-test"
-    });
-    expect(successResult).toBe(true);
-    expect(attempts).toBe(3);
-
-    //should not dequeue anything since stream should be empty
-    const emptyResult = await mq.dequeue(successHandler, {
-      stream: "rollback-test"
-    });
+    // Stream should be empty
+    const emptyResult = await mq.dequeue(successHandler, { stream: "rollback-test" });
     expect(emptyResult).toBe(false);
-    // should still be 3 attempts since we processed one message
-    expect(attempts).toBe(3);
   });
 
-  it("should prevent processing multiple messages from same stream concurrently", async () => {
-    // Enqueue multiple messages for the same stream
+  it("should prevent concurrent processing of same stream", async () => {
+    // Enqueue first message
     await mq.enqueue([
-      { name: "stream-lock", stream: "stream-lock-test", data: { value: "1" } },
-      { name: "stream-lock", stream: "stream-lock-test", data: { value: "2" } },
-      { name: "stream-lock", stream: "stream-lock-test", data: { value: "3" } }
+      { name: "concurrent", stream: "stream-test", data: { value: "1" } },
     ]);
 
-    let currentlyProcessing = false;
     const processedMessages: string[] = [];
-    const processingStarts: { value: string; time: number }[] = [];
-    const processingEnds: { value: string; time: number }[] = [];
+    let firstMessageStarted = false;
+    const processingMessage = new Promise<void>((resolve) => {
+      setTimeout(resolve, 200);
+    });
 
-    // Create a handler that tracks concurrent processing
-    const handler = async (message: Message): Promise<void> => {
+    const handler = async (message: Message) => {
       const value = message.data.value as string;
-      const startTime = Date.now();
-
-      log().info(`Attempting to process message ${value}`);
-      processingStarts.push({ value, time: startTime });
-
-      // Assert that no other message from this stream is being processed
-      if (currentlyProcessing) {
-        throw new Error(`Concurrent processing detected for message ${value}`);
-      }
-
-      currentlyProcessing = true;
-
-      // Simulate some processing time
-      await sleep(500);
-
       processedMessages.push(value);
-      currentlyProcessing = false;
-
-      const endTime = Date.now();
-      processingEnds.push({ value, time: endTime });
-      log().info(`Finished processing message ${value}`);
+      
+      if (value === "1") {
+        firstMessageStarted = true;  // Signal that first message processing has started
+        await processingMessage;
+      }
     };
 
-    // Try to process messages concurrently
-    const dequeuePromises = [
-      mq.dequeue(handler, { stream: "stream-lock-test" }),
-      mq.dequeue(handler, { stream: "stream-lock-test" }),
-      mq.dequeue(handler, { stream: "stream-lock-test" })
-    ];
+    // Start first dequeue
+    const dequeue1Promise = mq.dequeue(handler, { stream: "stream-test" });
+    
+    // Wait for first message to actually start processing
+    while (!firstMessageStarted) {
+      await sleep(10);
+    }
+    
+    // Now we know the lock is held, proceed with second message
+    await mq.enqueue([
+      { name: "concurrent", stream: "stream-test", data: { value: "2" } },
+    ]);
 
-    const results = await Promise.all(dequeuePromises);
+    const dequeue2Promise = mq.dequeue(handler, { stream: "stream-test" });
 
-    // Log processing details
-    log().info("Processed messages in order:", processedMessages);
-    log().info("Processing starts:", processingStarts);
-    log().info("Processing ends:", processingEnds);
-    log().info("Dequeue results:", results);
+    const [result1, result2] = await Promise.all([
+      dequeue1Promise,
+      dequeue2Promise
+    ]);
 
-    // Only one dequeue operation should succeed
-    const successCount = results.filter((result) => result === true).length;
-    expect(successCount).toBe(1);
+    expect(result1).toBe(true);
+    expect(result2).toBe(false);
+    
+    // Only the first message should be processed
+    expect(processedMessages).toEqual(["1"]);
 
-    // Only one message should be processed
-    expect(processedMessages.length).toBe(1);
-    expect(processedMessages[0]).toBe("1"); // Should be the first message
+    // Now we should be able to process the second message
+    const result3 = await mq.dequeue(handler, { stream: "stream-test" });
+    expect(result3).toBe(true);
+    expect(processedMessages).toEqual(["1", "2"]);
+  });
 
-    // Now we should be able to process the next message
-    const result2 = await mq.dequeue(handler, { stream: "stream-lock-test" });
+  it("should allow concurrent processing of different streams", async () => {
+    await mq.enqueue([
+      { name: "multi", stream: "stream-1", data: { value: "1" } },
+      { name: "multi", stream: "stream-2", data: { value: "2" } }
+    ]);
+
+    const processedMessages: string[] = [];
+    const handler = async (message: Message) => {
+      await sleep(100); // Simulate processing time
+      processedMessages.push(message.data.value as string);
+    };
+
+    // Process different streams concurrently
+    const [result1, result2] = await Promise.all([
+      mq.dequeue(handler, { stream: "stream-1" }),
+      mq.dequeue(handler, { stream: "stream-2" })
+    ]);
+
+    expect(result1).toBe(true);
     expect(result2).toBe(true);
     expect(processedMessages.length).toBe(2);
-    expect(processedMessages[1]).toBe("2"); // Should be the second message
-
-    // And the final message
-    const result3 = await mq.dequeue(handler, { stream: "stream-lock-test" });
-    expect(result3).toBe(true);
-    expect(processedMessages.length).toBe(3);
-    expect(processedMessages[2]).toBe("3"); // Should be the third message
-
-    // Verify messages were processed in order
-    expect(processedMessages).toEqual(["1", "2", "3"]);
-
-    // Verify no more messages are available
-    const emptyResult = await mq.dequeue(handler, {
-      stream: "stream-lock-test"
-    });
-    expect(emptyResult).toBe(false);
+    expect(new Set(processedMessages)).toEqual(new Set(["1", "2"]));
   });
 
-  it("should handle unstreamed messages correctly", async () => {
-    // Enqueue multiple unstreamed messages
+  it("should handle unstreamed messages", async () => {
     await mq.enqueue([
       { name: "unstreamed", data: { value: "1" } },
-      { name: "unstreamed", data: { value: "2" } },
-      { name: "unstreamed", data: { value: "3" } },
-      { name: "unstreamed", data: { value: "4" } }
+      { name: "unstreamed", data: { value: "2" } }
     ]);
 
     const processedMessages: string[] = [];
-    const processing = new Set<string>();
-    let maxConcurrent = 0;
-    const processingOrder: string[] = [];
-
-    // Create a promise that resolves when first message starts processing
-    let firstProcessingResolve: () => void;
-    const firstProcessingPromise = new Promise<void>((resolve) => {
-      firstProcessingResolve = resolve;
-    });
-
-    // Try to process multiple messages concurrently
-    const results = await Promise.all([
-      mq.dequeue(
-        async (message) => {
-          const value = message.data.value as string;
-          processing.add(value);
-          maxConcurrent = Math.max(maxConcurrent, processing.size);
-          processingOrder.push(`start-${value}`);
-
-          if (processing.size === 1) {
-            firstProcessingResolve();
-            // First message waits longer
-            await sleep(100);
-          } else {
-            // Subsequent messages process faster
-            await sleep(50);
-          }
-
-          processingOrder.push(`end-${value}`);
-          processing.delete(value);
-          processedMessages.push(value);
-        },
-        { stream: undefined }
-      ),
-
-      // Wait for first message to start processing before starting others
-      (async () => {
-        await firstProcessingPromise;
-        return mq.dequeue(
-          async (message) => {
-            const value = message.data.value as string;
-            processing.add(value);
-            maxConcurrent = Math.max(maxConcurrent, processing.size);
-            processingOrder.push(`start-${value}`);
-            await sleep(50);
-            processingOrder.push(`end-${value}`);
-            processing.delete(value);
-            processedMessages.push(value);
-          },
-          { stream: undefined }
-        );
-      })(),
-
-      (async () => {
-        await firstProcessingPromise;
-        return mq.dequeue(
-          async (message) => {
-            const value = message.data.value as string;
-            processing.add(value);
-            maxConcurrent = Math.max(maxConcurrent, processing.size);
-            processingOrder.push(`start-${value}`);
-            await sleep(50);
-            processingOrder.push(`end-${value}`);
-            processing.delete(value);
-            processedMessages.push(value);
-          },
-          { stream: undefined }
-        );
-      })()
-    ]);
-
-    // Verify concurrent processing occurred
-    expect(maxConcurrent).toBeGreaterThan(1);
-
-    // Should have processed multiple messages
-    // eslint-disable-next-line require-await
-    const successCount = results.filter((r) => r === true).length;
-    expect(successCount).toBeGreaterThan(1);
-
-    // Process remaining message
-    while (processedMessages.length < 4) {
-      const result = await mq.dequeue(
-        (message) => {
-          const value = message.data.value as string;
-          processingOrder.push(`start-${value}`);
-          processingOrder.push(`end-${value}`);
-          processedMessages.push(value);
-          return Promise.resolve();
-        },
-        { stream: undefined }
-      );
-      expect(result).toBe(true);
-    }
-
-    // Verify all messages were processed
-    expect(processedMessages.length).toBe(4);
-    expect(new Set(processedMessages)).toEqual(new Set(["1", "2", "3", "4"]));
-
-    // Verify concurrent processing by checking processing order
-    const startIndices = processingOrder
-      .map((entry, index) => (entry.startsWith("start-") ? index : -1))
-      .filter((index) => index !== -1);
-
-    const endIndices = processingOrder
-      .map((entry, index) => (entry.startsWith("end-") ? index : -1))
-      .filter((index) => index !== -1);
-
-    // Verify that at least one message started processing before another finished
-    const hasOverlap = startIndices.some(
-      (startIdx, i) => i > 0 && startIdx < endIndices[i - 1]
-    );
-    expect(hasOverlap).toBe(true);
-
-    // Verify no more messages
-    const emptyResult = await mq.dequeue(async () => {}, { stream: undefined });
-    expect(emptyResult).toBe(false);
-  });
-
-  it("should maintain message order within streams when processing multiple streams concurrently", async () => {
-    // Enqueue interleaved messages from different streams
-    await mq.enqueue([
-      { name: "multi", stream: "stream-1", data: { value: "1-1" } },
-      { name: "multi", stream: "stream-2", data: { value: "2-1" } },
-      { name: "multi", stream: "stream-1", data: { value: "1-2" } },
-      { name: "multi", stream: "stream-2", data: { value: "2-2" } },
-      { name: "multi", stream: "stream-1", data: { value: "1-3" } },
-      { name: "multi", stream: "stream-2", data: { value: "2-3" } },
-      { name: "multi", stream: "stream-3", data: { value: "3-1" } },
-      { name: "multi", stream: "stream-1", data: { value: "1-4" } },
-      { name: "multi", stream: "stream-3", data: { value: "3-2" } },
-      { name: "multi", stream: "stream-2", data: { value: "2-4" } }
-    ]);
-
-    const processedByStream: Record<string, string[]> = {
-      "stream-1": [],
-      "stream-2": [],
-      "stream-3": []
+    const handler = (message: Message) => {
+      processedMessages.push(message.data.value as string);
+      return Promise.resolve();
     };
 
-    // Process all streams concurrently multiple times
-    const processingRounds = 4; // Enough rounds to process all messages
-    for (let i = 0; i < processingRounds; i++) {
-      await Promise.all([
-        mq.dequeue(
-          async (message) => {
-            await sleep(Math.random() * 50); // Random processing time
-            const stream = message.stream || "";
-            processedByStream[stream].push(message.data.value as string);
-          },
-          { stream: "stream-1" }
-        ),
-        mq.dequeue(
-          async (message) => {
-            await sleep(Math.random() * 50); // Random processing time
-            const stream = message.stream || "";
-            processedByStream[stream].push(message.data.value as string);
-          },
-          { stream: "stream-2" }
-        ),
-        mq.dequeue(
-          async (message) => {
-            await sleep(Math.random() * 50); // Random processing time
-            const stream = message.stream || "";
-            processedByStream[stream].push(message.data.value as string);
-          },
-          { stream: "stream-3" }
-        )
-      ]);
-    }
+    const result1 = await mq.dequeue(handler, {});
+    const result2 = await mq.dequeue(handler, {});
+    const result3 = await mq.dequeue(handler, {});
 
-    // Verify order within each stream
-    expect(processedByStream["stream-1"]).toEqual(["1-1", "1-2", "1-3", "1-4"]);
-    expect(processedByStream["stream-2"]).toEqual(["2-1", "2-2", "2-3", "2-4"]);
-    expect(processedByStream["stream-3"]).toEqual(["3-1", "3-2"]);
-
-    // Verify no more messages in any stream
-    const results = await Promise.all([
-      mq.dequeue(async () => {}, { stream: "stream-1" }),
-      mq.dequeue(async () => {}, { stream: "stream-2" }),
-      mq.dequeue(async () => {}, { stream: "stream-3" })
-    ]);
-    expect(results.every((r) => r === false)).toBe(true);
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(result3).toBe(false); // No more messages
+    expect(processedMessages.length).toBe(2);
   });
 
-  it("should correctly handle a mix of streamed and unstreamed messages", async () => {
-    // Enqueue mix of streamed and unstreamed messages
+  it("should respect lease duration", async () => {
     await mq.enqueue([
-      { name: "mixed", stream: "stream-1", data: { value: "1-1" } },
-      { name: "mixed", data: { value: "u-1" } },
-      { name: "mixed", stream: "stream-2", data: { value: "2-1" } },
-      { name: "mixed", data: { value: "u-2" } },
-      { name: "mixed", stream: "stream-1", data: { value: "1-2" } },
-      { name: "mixed", stream: "stream-2", data: { value: "2-2" } },
-      { name: "mixed", data: { value: "u-3" } },
-      { name: "mixed", stream: "stream-1", data: { value: "1-3" } },
-      { name: "mixed", data: { value: "u-4" } },
-      { name: "mixed", stream: "stream-2", data: { value: "2-3" } }
+      { name: "lease", stream: "lease-test", data: { value: "1" } }
     ]);
 
-    const processedByStream: Record<string, string[]> = {
-      "stream-1": [],
-      "stream-2": [],
-      unstreamed: []
+    // First handler that will fail
+    const handler1 = () => {
+      throw new Error('Simulated failure');
     };
 
-    // Track concurrent processing
-    const activeProcessing = new Set<string>();
-    let streamProcessingOverlap = false;
-    let hadConcurrentUnstreamed = false;
+    const result1 = await mq.dequeue(handler1, { 
+      stream: "lease-test",
+      leaseMillis: 100 
+    }).catch(() => false);
 
-    // Promises to coordinate unstreamed message processing
-    let firstUnstreamedStarted = false;
-    let firstUnstreamedResolve: (x: unknown) => void;
-
-    const firstUnstreamedProcessing = new Promise((resolve) => {
-      firstUnstreamedResolve = resolve;
-    });
-
-    // Process streamed and unstreamed messages concurrently
-    await Promise.all([
-      // First unstreamed processor - start this first
-      mq.dequeue(
-        async (message) => {
-          firstUnstreamedStarted = true;
-          activeProcessing.add("unstreamed");
-          processedByStream["unstreamed"].push(message.data.value as string);
-          await sleep(100); // Longer sleep to ensure overlap opportunity
-          firstUnstreamedResolve(undefined);
-          activeProcessing.delete("unstreamed");
-        },
-        { stream: undefined }
-      ),
-
-      // Wait briefly to ensure first unstreamed has started
-      (async () => {
-        await sleep(50);
-        return mq.dequeue(
-          async (message) => {
-            if (firstUnstreamedStarted && activeProcessing.has("unstreamed")) {
-              hadConcurrentUnstreamed = true;
-            }
-            activeProcessing.add("unstreamed");
-            processedByStream["unstreamed"].push(message.data.value as string);
-            await sleep(10);
-            activeProcessing.delete("unstreamed");
-          },
-          { stream: undefined }
-        );
-      })(),
-
-      // Stream processors can start whenever
-      mq.dequeue(
-        async (message) => {
-          const stream = "stream-1";
-          if (activeProcessing.has(stream)) streamProcessingOverlap = true;
-          activeProcessing.add(stream);
-          await sleep(10);
-          activeProcessing.delete(stream);
-          processedByStream[stream].push(message.data.value as string);
-        },
-        { stream: "stream-1" }
-      ),
-
-      mq.dequeue(
-        async (message) => {
-          const stream = "stream-2";
-          if (activeProcessing.has(stream)) streamProcessingOverlap = true;
-          activeProcessing.add(stream);
-          await sleep(10);
-          activeProcessing.delete(stream);
-          processedByStream[stream].push(message.data.value as string);
-        },
-        { stream: "stream-2" }
-      )
-    ]);
-
-    // Wait for first unstreamed to complete
-    await firstUnstreamedProcessing;
-
-    // Process remaining messages
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const streamResults = await Promise.all([
-        mq.dequeue(
-          async (message) => {
-            const stream = "stream-1";
-            if (activeProcessing.has(stream)) streamProcessingOverlap = true;
-            activeProcessing.add(stream);
-            await sleep(10);
-            activeProcessing.delete(stream);
-            processedByStream[stream].push(message.data.value as string);
-          },
-          { stream: "stream-1" }
-        ),
-        mq.dequeue(
-          async (message) => {
-            const stream = "stream-2";
-            if (activeProcessing.has(stream)) streamProcessingOverlap = true;
-            activeProcessing.add(stream);
-            await sleep(10);
-            activeProcessing.delete(stream);
-            processedByStream[stream].push(message.data.value as string);
-          },
-          { stream: "stream-2" }
-        ),
-        mq.dequeue(
-          async (message) => {
-            if (activeProcessing.has("unstreamed")) {
-              hadConcurrentUnstreamed = true;
-            }
-            activeProcessing.add("unstreamed");
-            processedByStream["unstreamed"].push(message.data.value as string);
-            await sleep(10);
-            activeProcessing.delete("unstreamed");
-          },
-          { stream: undefined }
-        )
-      ]);
-
-      if (streamResults.every((r) => r === false)) break;
-    }
-
-    // Verify order within streamed messages
-    expect(processedByStream["stream-1"]).toEqual(["1-1", "1-2", "1-3"]);
-    expect(processedByStream["stream-2"]).toEqual(["2-1", "2-2", "2-3"]);
-
-    // Verify all unstreamed messages were processed
-    expect(processedByStream["unstreamed"].length).toBe(4);
-    expect(new Set(processedByStream["unstreamed"])).toEqual(
-      new Set(["u-1", "u-2", "u-3", "u-4"])
+    await sleep(150);
+    
+    const result2 = await mq.dequeue(() => Promise.resolve(), 
+      { stream: "lease-test" }
     );
-
-    // Verify concurrent processing of unstreamed messages occurred
-    expect(hadConcurrentUnstreamed).toBe(true);
-
-    // Verify no concurrent processing within streams
-    expect(streamProcessingOverlap).toBe(false);
+    
+    expect(result1).toBe(false);  // First handler failed
+    expect(result2).toBe(true);   // Second handler should succeed
   });
 });

--- a/libs/eventually-pg/src/__tests__/ordered-message-queue.spec.ts
+++ b/libs/eventually-pg/src/__tests__/ordered-message-queue.spec.ts
@@ -1,0 +1,287 @@
+import { dispose, Message, sleep } from "@rotorsoft/eventually";
+import { PostgresOrderedMessageQueue } from "../PostgresOrderedMessageQueue";
+
+const table = "ordered_message_queue_test";
+const mq = PostgresOrderedMessageQueue(table);
+
+describe("message queue", () => {
+  beforeAll(async () => {
+    await mq.drop();
+    await mq.seed();
+  });
+
+  afterAll(async () => {
+    await dispose()();
+  });
+
+  it("should enqueue and dequeue in order", async () => {
+    await mq.enqueue([
+      { name: "order", stream: "order-test", data: { value: "1" } },
+      { name: "order", stream: "order-test", data: { value: "2" } },
+      { name: "order", stream: "order-test", data: { value: "3" } }
+    ]);
+
+    const processedOrder: string[] = [];
+    const handler = (message: Message) => {
+      processedOrder.push(message.data.value as string);
+      return Promise.resolve();
+    };
+
+    // Process all messages sequentially
+    const result1 = await mq.dequeue(handler, { stream: "order-test" });
+    const result2 = await mq.dequeue(handler, { stream: "order-test" });
+    const result3 = await mq.dequeue(handler, { stream: "order-test" });
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(result3).toBe(true);
+    expect(processedOrder).toEqual(["1", "2", "3"]);
+
+    // Verify no more messages
+    const emptyResult = await mq.dequeue(handler, { stream: "order-test" });
+    expect(emptyResult).toBe(false);
+  });
+
+  it("should handle transaction rollback on error", async () => {
+    await mq.enqueue([
+      { name: "rollback", stream: "rollback-test", data: { value: "1" } }
+    ]);
+
+    let attempts = 0;
+    const failHandler = () => {
+      attempts++;
+      throw new Error("Simulated failure");
+    };
+
+    // First attempt should fail and rollback
+    await expect(
+      mq.dequeue(failHandler, { stream: "rollback-test" })
+    ).rejects.toThrow("Simulated failure");
+
+    // Message should be available for retry
+    const successHandler = () => {
+      attempts++;
+      return Promise.resolve();
+    };
+    const result = await mq.dequeue(successHandler, { stream: "rollback-test" });
+    expect(result).toBe(true);
+    expect(attempts).toBe(2);
+
+    // Stream should be empty
+    const emptyResult = await mq.dequeue(successHandler, { stream: "rollback-test" });
+    expect(emptyResult).toBe(false);
+  });
+
+  it("should prevent concurrent processing of same stream", async () => {
+    // Enqueue first message
+    await mq.enqueue([
+      { name: "concurrent", stream: "stream-test", data: { value: "1" } },
+    ]);
+
+    const processedMessages: string[] = [];
+    let firstMessageStarted = false;
+    const processingMessage = new Promise<void>((resolve) => {
+      setTimeout(resolve, 200);
+    });
+
+    const handler = async (message: Message) => {
+      const value = message.data.value as string;
+      processedMessages.push(value);
+      
+      if (value === "1") {
+        firstMessageStarted = true;  // Signal that first message processing has started
+        await processingMessage;
+      }
+    };
+
+    // Start first dequeue
+    const dequeue1Promise = mq.dequeue(handler, { stream: "stream-test" });
+    
+    // Wait for first message to actually start processing
+    while (!firstMessageStarted) {
+      await sleep(10);
+    }
+    
+    // Now we know the lock is held, proceed with second message
+    await mq.enqueue([
+      { name: "concurrent", stream: "stream-test", data: { value: "2" } },
+    ]);
+
+    const dequeue2Promise = mq.dequeue(handler, { stream: "stream-test" });
+
+    const [result1, result2] = await Promise.all([
+      dequeue1Promise,
+      dequeue2Promise
+    ]);
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(false);
+    
+    // Only the first message should be processed
+    expect(processedMessages).toEqual(["1"]);
+
+    // Now we should be able to process the second message
+    const result3 = await mq.dequeue(handler, { stream: "stream-test" });
+    expect(result3).toBe(true);
+    expect(processedMessages).toEqual(["1", "2"]);
+  });
+
+  it("should allow concurrent processing of different streams", async () => {
+    await mq.enqueue([
+      { name: "multi", stream: "stream-1", data: { value: "1" } },
+      { name: "multi", stream: "stream-2", data: { value: "2" } }
+    ]);
+
+    const processedMessages: string[] = [];
+    const handler = async (message: Message) => {
+      await sleep(100); // Simulate processing time
+      processedMessages.push(message.data.value as string);
+    };
+
+    // Process different streams concurrently
+    const [result1, result2] = await Promise.all([
+      mq.dequeue(handler, { stream: "stream-1" }),
+      mq.dequeue(handler, { stream: "stream-2" })
+    ]);
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(processedMessages.length).toBe(2);
+    expect(new Set(processedMessages)).toEqual(new Set(["1", "2"]));
+  });
+
+  it("should handle unstreamed messages", async () => {
+    await mq.enqueue([
+      { name: "unstreamed", data: { value: "1" } },
+      { name: "unstreamed", data: { value: "2" } }
+    ]);
+
+    const processedMessages: string[] = [];
+    const handler = (message: Message) => {
+      processedMessages.push(message.data.value as string);
+      return Promise.resolve();
+    };
+
+    const result1 = await mq.dequeue(handler, {});
+    const result2 = await mq.dequeue(handler, {});
+    const result3 = await mq.dequeue(handler, {});
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(result3).toBe(false); // No more messages
+    expect(processedMessages.length).toBe(2);
+  });
+
+  it("should respect lease duration", async () => {
+    await mq.enqueue([
+      { name: "lease", stream: "lease-test", data: { value: "1" } }
+    ]);
+
+    // First handler that will fail
+    const handler1 = () => {
+      throw new Error('Simulated failure');
+    };
+
+    const result1 = await mq.dequeue(handler1, { 
+      stream: "lease-test",
+      leaseMillis: 100 
+    }).catch(() => false);
+
+    await sleep(150);
+    
+    const result2 = await mq.dequeue(() => Promise.resolve(), 
+      { stream: "lease-test" }
+    );
+    
+    expect(result1).toBe(false);  // First handler failed
+    expect(result2).toBe(true);   // Second handler should succeed
+  });
+
+  it("should prevent message processing during aggressive concurrent attempts", async () => {
+    // Increase timeout since we're doing lots of concurrent operations
+    jest.setTimeout(30000);
+
+    // Enqueue initial messages for two different streams
+    await mq.enqueue([
+      { name: "aggressive", stream: "aggressive-test-1", data: { value: "1" } },
+      { name: "aggressive", stream: "aggressive-test-2", data: { value: "2" } }
+    ]);
+
+    const processedMessages: string[] = [];
+    let firstStreamStarted = false;
+    let secondStreamStarted = false;
+    const processingDelay = new Promise<void>(resolve => setTimeout(resolve, 500));
+
+    const slowHandler = async (message: Message) => {
+      const value = message.data.value as string;
+      processedMessages.push(value);
+      
+      if (value === "1") {
+        firstStreamStarted = true;
+      }
+      if (value === "2") {
+        secondStreamStarted = true;
+      }
+      await processingDelay;
+    };
+
+    // Start processing both streams without specifying streams
+    const firstDequeue = mq.dequeue(slowHandler);
+    const secondDequeue = mq.dequeue(slowHandler);
+
+    // Wait for both streams to start processing
+    while (!firstStreamStarted || !secondStreamStarted) {
+      await sleep(10);
+
+    }
+
+    // Try to aggressively process messages while first ones are still processing
+    // Reduced number of concurrent attempts to avoid connection pool exhaustion
+    const attempts = 100;
+    const concurrentAttempts = Array(attempts).fill(null).map(() => 
+      mq.dequeue(slowHandler)
+    );
+
+    const results = await Promise.all([firstDequeue, secondDequeue, ...concurrentAttempts]);
+
+    // First two dequeues should succeed, all others should fail
+    expect(results[0]).toBe(true);
+    expect(results[1]).toBe(true);
+    results.slice(2).forEach(result => {
+      expect(result).toBe(false);
+    });
+
+    // Only first two messages should be processed
+    expect(processedMessages).toHaveLength(2);
+    expect(new Set(processedMessages)).toEqual(new Set(["1", "2"]));
+
+  }); // Set timeout at test level as well
+
+  it("should dequeue any message when no stream name is provided", async () => {
+    // Enqueue messages with and without streams
+    await mq.enqueue([
+      { name: "no-opts", stream: "stream-1", data: { value: "1" } },
+      { name: "no-opts", data: { value: "2" } },  // No stream
+      { name: "no-opts", stream: "stream-2", data: { value: "3" } }
+    ]);
+
+    const processedMessages: string[] = [];
+    const handler = async (message: Message) => {
+      processedMessages.push(message.data.value as string);
+      await sleep(100);
+    };
+
+    // Dequeue without providing any options
+    const result1 = await mq.dequeue(handler);
+    const result2 = await mq.dequeue(handler);
+    const result3 = await mq.dequeue(handler);
+    const result4 = await mq.dequeue(handler);
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(result3).toBe(true);
+    expect(result4).toBe(false);  // No more messages
+    expect(processedMessages.length).toBe(3);
+    expect(new Set(processedMessages)).toEqual(new Set(["1", "2", "3"]));
+  });
+});

--- a/libs/eventually-pg/src/seed.ts
+++ b/libs/eventually-pg/src/seed.ts
@@ -170,8 +170,15 @@ CREATE TABLE IF NOT EXISTS public."${table}"
   name varchar(100) COLLATE pg_catalog."default" NOT NULL,
   stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
   data jsonb NOT NULL,
-  created timestamptz NOT NULL DEFAULT now()
+  created timestamptz NOT NULL DEFAULT now(),
+  locked_by varchar(20),
+  locked_until timestamptz
 ) TABLESPACE pg_default;
+
+-- Partial unique index that enforces only one locked message per stream
+CREATE UNIQUE INDEX IF NOT EXISTS "${table}_stream_lock_ix"
+  ON public."${table}" (stream)
+  WHERE locked_by IS NOT NULL;
 
 -- Index to support the ORDER BY created ASC, id ASC in dequeue
 CREATE INDEX IF NOT EXISTS "${table}_dequeue_ix"

--- a/libs/eventually-pg/src/seed.ts
+++ b/libs/eventually-pg/src/seed.ts
@@ -170,8 +170,16 @@ CREATE TABLE IF NOT EXISTS public."${table}"
   name varchar(100) COLLATE pg_catalog."default" NOT NULL,
   stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
   data jsonb NOT NULL,
-  created timestamptz NOT NULL DEFAULT now(),
-  locked_until timestamptz,
-  CONSTRAINT "${table}_queue_unique_stream_id" UNIQUE (stream, id)
+  created timestamptz NOT NULL DEFAULT now()
 ) TABLESPACE pg_default;
+
+-- Index to support the ORDER BY created ASC, id ASC in dequeue
+CREATE INDEX IF NOT EXISTS "${table}_dequeue_ix"
+  ON public."${table}" USING btree (stream, created ASC, id ASC)
+  TABLESPACE pg_default;
+
+-- Index to support fast deletions by id
+CREATE INDEX IF NOT EXISTS "${table}_id_ix"
+  ON public."${table}" USING btree (id)
+  TABLESPACE pg_default;
 `;

--- a/libs/eventually-pg/src/seed.ts
+++ b/libs/eventually-pg/src/seed.ts
@@ -171,6 +171,19 @@ CREATE TABLE IF NOT EXISTS public."${table}"
   stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
   data jsonb NOT NULL,
   created timestamptz NOT NULL DEFAULT now(),
+  locked_until timestamptz,
+  CONSTRAINT "${table}_queue_unique_stream_id" UNIQUE (stream, id)
+) TABLESPACE pg_default;
+`;
+
+export const ordered_message_queue = (table: string): string => `
+CREATE TABLE IF NOT EXISTS public."${table}"
+(
+  id serial PRIMARY KEY,
+  name varchar(100) COLLATE pg_catalog."default" NOT NULL,
+  stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
+  data jsonb NOT NULL,
+  created timestamptz NOT NULL DEFAULT now(),
   locked_by varchar(20),
   locked_until timestamptz
 ) TABLESPACE pg_default;

--- a/libs/eventually/src/interfaces/stores.ts
+++ b/libs/eventually/src/interfaces/stores.ts
@@ -178,14 +178,19 @@ export interface MessageQueue<M extends Messages> extends Disposable {
   /**
    * Dequeues message on top of the queue after being processed by consumer callback
    * @param callback consumer callback that receives the message with storage attributes {id, created} and returns a promise or error
-   * @param stream optional stream name to support independent concurrent consumers
-   * @returns promise that resolves true when message is successfully processed, resolves false when stream is empty, rejects when message is not processed
-  */
+   * @param opts options for dequeuing
+   * @param opts.stream optional stream name to support independent concurrent consumers
+   * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default: 30000)
+   * @returns promise that resolves true when message is successfully processed, resolves false when stream is empty or lock cannot be acquired, rejects when message is not processed
+   */
   dequeue: (
     callback: (
       message: Message<M> & { id: number | string; created: Date }
     ) => Promise<void>,
-    opts: { stream?: string; }
+    opts: { 
+      stream?: string;
+      leaseMillis?: number;
+    }
   ) => Promise<boolean>;
 
   /**

--- a/libs/eventually/src/interfaces/stores.ts
+++ b/libs/eventually/src/interfaces/stores.ts
@@ -180,8 +180,9 @@ export interface MessageQueue<M extends Messages> extends Disposable {
    * @param callback consumer callback that receives the message with storage attributes {id, created} and returns a promise or error
    * @param opts optional options for dequeuing
    * @param opts.stream optional stream name to support independent concurrent consumers
-   * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default: 30000)
-   * @returns promise that resolves true when message is successfully processed, resolves false when stream is empty or lock cannot be acquired, rejects when message is not processed
+   * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default dictated by adapter)
+   * @returns promise that resolves true when message is successfully processed, false when stream is empty or lock cannot be acquired,
+   *          rejects when message has failed to be processed
    */
   dequeue: (
     callback: (

--- a/libs/eventually/src/interfaces/stores.ts
+++ b/libs/eventually/src/interfaces/stores.ts
@@ -178,7 +178,7 @@ export interface MessageQueue<M extends Messages> extends Disposable {
   /**
    * Dequeues message on top of the queue after being processed by consumer callback
    * @param callback consumer callback that receives the message with storage attributes {id, created} and returns a promise or error
-   * @param opts options for dequeuing
+   * @param opts optional options for dequeuing
    * @param opts.stream optional stream name to support independent concurrent consumers
    * @param opts.leaseMillis optional lease duration in milliseconds before lock expires (default: 30000)
    * @returns promise that resolves true when message is successfully processed, resolves false when stream is empty or lock cannot be acquired, rejects when message is not processed
@@ -187,7 +187,7 @@ export interface MessageQueue<M extends Messages> extends Disposable {
     callback: (
       message: Message<M> & { id: number | string; created: Date }
     ) => Promise<void>,
-    opts: { 
+    opts?: { 
       stream?: string;
       leaseMillis?: number;
     }


### PR DESCRIPTION
Experimental (but tested) implementation that allows concurrent processing of queue messages whilst guaranteeing that only one message from each stream is allowed to be locked/processing at any given time.  Uses a pessimistic locking mechanism that is supported by a partial unique index constraint.  Row level locking during callback processing is not needed since only one process is allowed to acquire the lock (set locked_by on one message in a stream).  After succesful callback processing the message is deleted.  The lock is explicitly released on callback failure.  If delete or explicit lock release fails then we fall back to automatic expiry mechanism using locked_until field.  This would comport with in-order but at-least-once stream processing semantics.

One caveat to mention...enqueueing messages with an undefined stream is the same as enqueueing a message with a stream: '' (empty string).  This dequeue implementation would treat unstreamed messages as one stream and thus only allow for one unstreamed message to be dequeued at any given time.